### PR TITLE
[TASK] EXT:solr 4.0.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
 		"source": "https://github.com/TYPO3-Solr/ext-solrgrouping"
 	},
 	"require": {
-		"php": ">=5.3.7 <6.0",
-		"typo3/cms-core": ">=6.2.14,<8.0"
+		"php": ">=5.5.0",
+		"typo3/cms-core": ">=7.6.0,<8.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8.0"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,8 +15,8 @@ $EM_CONF[$_EXTKEY] = array(
     'clearCacheOnLoad' => 0,
     'constraints' => array(
         'depends' => array(
-            'solr' => '3.1.0-',
-            'typo3' => '6.2.0-7.99.99',
+            'solr' => '4.0.2-',
+            'typo3' => '7.6.0-8.0.99',
         ),
         'conflicts' => array(),
         'suggests' => array(),


### PR DESCRIPTION
- Allow to install with php7 and TYPO3 8.0
- Set required EXT:solr version to 4.0.2
