### PR TITLE
[TASK] Check compatibility with EXT:solr 6.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	},
 	"require": {
 		"php": ">=5.5.0",
-		"typo3/cms-core": ">=7.6.0,<8.1"
+		"typo3/cms-core": ">=7.6.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8.0"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,7 +15,7 @@ $EM_CONF[$_EXTKEY] = array(
     'clearCacheOnLoad' => 0,
     'constraints' => array(
         'depends' => array(
-            'solr' => '4.0.2-',
+            'solr' => '5.0.0-',
             'typo3' => '7.6.0-8.0.99',
         ),
         'conflicts' => array(),


### PR DESCRIPTION
Checked compaibility with 6.0.0

- The changes using the configuration object require at least EXT:solr 5.0.0 usage with 6.0.0 is also fine.

Fixes: #11